### PR TITLE
added missing werkzeug.exceptions import

### DIFF
--- a/publicprize/common.py
+++ b/publicprize/common.py
@@ -15,6 +15,7 @@ import sqlalchemy
 import sys
 import urllib.parse
 import urllib.request
+import werkzeug.exceptions
 
 from . import controller as ppc
 from . import biv


### PR DESCRIPTION
I noticed this when trying to access the admin page as a normal user. The server tries to send out a 403 error using werkzeug in publicprize/common.py.